### PR TITLE
Set locked memory limit to unlimited

### DIFF
--- a/cmd/xdpcap/filter_test.go
+++ b/cmd/xdpcap/filter_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"os"
 	"testing"
 
 	"github.com/cloudflare/xdpcap"
@@ -13,6 +14,15 @@ import (
 var testOpts = FilterOpts{
 	PerfPerCPUBuffer: 8192,
 	PerfWatermark:    4096,
+}
+
+func TestMain(m *testing.M) {
+	err := unlimitLockedMemory()
+	if err != nil {
+		panic(err)
+	}
+
+	os.Exit(m.Run())
 }
 
 func TestEmptyExpr(t *testing.T) {

--- a/cmd/xdpcap/main.go
+++ b/cmd/xdpcap/main.go
@@ -56,6 +56,12 @@ func main() {
 }
 
 func capture(mapPath string, pcapPath string, filterExpr string, opts FilterOpts) error {
+	// BPF progs, maps and the perf buffer are stored in locked memory
+	err := unlimitLockedMemory()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error setting locked memory limit:", err)
+	}
+
 	pcapFile, err := os.Create(pcapPath)
 	if err != nil {
 		return errors.Wrap(err, "openning pcap")

--- a/cmd/xdpcap/memory.go
+++ b/cmd/xdpcap/memory.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	// syscall has a wonky RLIM_INFINITY, and no RLIMIT_MEMLOCK
+	"golang.org/x/sys/unix"
+)
+
+// unlimitLockedMemory removes any locked memory limits
+func unlimitLockedMemory() error {
+	return unix.Setrlimit(unix.RLIMIT_MEMLOCK, &unix.Rlimit{
+		Cur: unix.RLIM_INFINITY,
+		Max: unix.RLIM_INFINITY,
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,5 @@ require (
 	github.com/newtools/ebpf v0.0.0-20190313155020-23e0debb6338
 	github.com/pkg/errors v0.8.1
 	golang.org/x/net v0.0.0-20190324223953-e3b2ff56ed87
-	golang.org/x/sys v0.0.0-20190322080309-f49334f85ddc // indirect
+	golang.org/x/sys v0.0.0-20190322080309-f49334f85ddc
 )


### PR DESCRIPTION
Set the locked memory limit to unlimited on startup. We need locked
memory for the XDP programs, maps, and perf buffer which makes it hard
to estimate how much we actually need.

This only applies to the current process, so I don't think it's an
issue.

Closes #1