### PR TITLE
update commit ref for cbpfc

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/cloudflare/xdpcap
 
 require (
-	github.com/cloudflare/cbpfc v0.0.0-20190320162115-c25c3285ceea
+	github.com/cloudflare/cbpfc v0.0.0-20190318133550-6930ae692b19
 	github.com/google/gopacket v1.1.16
 	github.com/mdlayher/raw v0.0.0-20190315120451-8be9e99c38b6 // indirect
 	github.com/newtools/ebpf v0.0.0-20190313155020-23e0debb6338

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/cloudflare/cbpfc v0.0.0-20190320162115-c25c3285ceea h1:jYBYSbA/xovYFOkGhjmJXQP29wm6L7DmMuqJ53XxqB8=
-github.com/cloudflare/cbpfc v0.0.0-20190320162115-c25c3285ceea/go.mod h1:rKU7EPA0qEqSttdZG4w4xnDHc6dSQqJiNve0A2HeOec=
+github.com/cloudflare/cbpfc v0.0.0-20190318133550-6930ae692b19 h1:ypnSFsLr4StVy43d7h57naxKuqsoA5KzBhq3fkgz874=
+github.com/cloudflare/cbpfc v0.0.0-20190318133550-6930ae692b19/go.mod h1:rKU7EPA0qEqSttdZG4w4xnDHc6dSQqJiNve0A2HeOec=
 github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/gopacket v1.1.16 h1:u6Afvia5C5srlLcbTwpHaFW918asLYPxieziOaWwz8M=


### PR DESCRIPTION
This patch updates the reference to the [cbpfc](https://github.com/cloudflare/cbpfc) commit to point to a parent of its current master.

Currently the compilation of the master branch of `xdpcap` fails with:

```
go: github.com/cloudflare/cbpfc@v0.0.0-20190320162115-c25c3285ceea: unknown revision c25c3285ceea
go: error loading module requirements
```

It seems like there's been a history rewrite on  [9ae1b04](https://github.com/cloudflare/cbpfc/commit/9ae1b046dfb6ce015f1574568254888fa9645501) for `cbpfc` making [6930ae6](https://github.com/cloudflare/cbpfc/commit/6930ae692b19fac47f16d19195b81a930d1e7c6d) the correct ancestor of the current master of `cbpfc`. The commits seem to be otherwise equivalent, as far I can tell.