### PR TITLE
Basic TravisCI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: go
+dist: xenial
+
+go:
+  - 1.12.x
+
+env:
+  - GO111MODULE=on
+
+addons:
+  apt:
+    packages:
+      - libpcap0.8-dev
+
+script:
+  # gofmt doesn't report any changes
+  - test -z $(gofmt -l ./ | tee /dev/stderr)
+  # tests need to run as root to load XDP programs
+  - sudo -E env "PATH=$PATH" go test ./...


### PR DESCRIPTION
Add basic TravisCI integration, using the HWE kernel provided by the
Travis / GCE Xenial image directly: 4.15.

Use go 1.12, as gopacket depends on mdlayher/raw, which requires go 1.12.