### PR TITLE
Use a watermark of one by default

### DIFF
--- a/cmd/xdpcap/flags.go
+++ b/cmd/xdpcap/flags.go
@@ -62,7 +62,7 @@ func parseFlags(name string, args []string) (flags, error) {
 	}
 
 	flags.UintVar(&flags.filterOpts.perfPerCPUBuffer, "buffer", 8192, "Per CPU perf buffer size to create (`bytes`)")
-	flags.UintVar(&flags.filterOpts.perfWatermark, "watermark", 4096, "Perf watermark (`bytes`)")
+	flags.UintVar(&flags.filterOpts.perfWatermark, "watermark", 1, "Perf watermark (`bytes`)")
 	flags.BoolVar(&flags.quiet, "q", false, "Don't print statistics")
 	flags.BoolVar(&flags.flush, "flush", false, "Flush pcap data written to <output> for every packet received")
 

--- a/cmd/xdpcap/flags_test.go
+++ b/cmd/xdpcap/flags_test.go
@@ -174,7 +174,7 @@ func defaultFlags(mapPath string) flags {
 		filterExpr: "",
 		filterOpts: filterOpts{
 			perfPerCPUBuffer: 8192,
-			perfWatermark:    4096,
+			perfWatermark:    1,
 			actions:          []xdpAction{},
 		},
 	}


### PR DESCRIPTION
Using a higher watermark is in theory more efficient, since the process is woken
up less frequently. This is a problem when using xdpcap in interactive mode however,
because it means that only every 4k of packets are flushed. This makes it look like
no packets were sent when piping to tcpdump.

I suspect that removing the watermark flag completely would probably be fine.