### PR TITLE
bpfoff: Match encapsulated packets

### DIFF
--- a/cmd/bpfoff/main.go
+++ b/cmd/bpfoff/main.go
@@ -1,0 +1,197 @@
+// Program bpfoff converts a tcpdump / libpcap filter expression to a BPF filter matching packets with a fixed set of byte offsets.
+// Useful for matching encapsulated packets.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"math"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/cloudflare/xdpcap/internal"
+
+	"github.com/google/gopacket/layers"
+	"github.com/pkg/errors"
+	"golang.org/x/net/bpf"
+)
+
+func main() {
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, `%s [options] <offsets> <tcpdump filter expr>
+
+Convert <tcpdump filter expr> to a BPF filter matching packets with a fixed set of byte offsets, in the comma separated <offsets>.
+<tcpdump filter expr> must be a layer 3 (IP) and up filter.
+This allows encapsulated packets with fixed header sizes to be matched.
+`, os.Args[0])
+		flag.PrintDefaults()
+	}
+
+	flag.Parse()
+
+	if flag.NArg() < 2 {
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	offsets, err := parseOffsets(flag.Arg(0))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error parsing offsets:", err)
+		os.Exit(1)
+	}
+
+	filterExpr := strings.Join(flag.Args()[1:], " ")
+
+	filter, err := addOffsets(offsets, filterExpr)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error converting filter:", err)
+		os.Exit(1)
+	}
+
+	err = printFilter(filter)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Internal error:", err)
+		os.Exit(1)
+	}
+}
+
+func parseOffsets(offsets string) ([]uint32, error) {
+	offs := []uint32{}
+
+	for _, offsetStr := range strings.Split(offsets, ",") {
+		off, err := strconv.ParseUint(offsetStr, 0, 32)
+		if err != nil {
+			return nil, err
+		}
+
+		offs = append(offs, uint32(off))
+	}
+
+	return offs, nil
+}
+
+// printFilter prints a filter in the standard / linux form to stdout
+func printFilter(filter []bpf.Instruction) error {
+	fmt.Printf("%d", len(filter))
+
+	for _, insn := range filter {
+		raw, err := insn.Assemble()
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf(",%d %d %d %d", raw.Op, raw.Jt, raw.Jf, raw.K)
+	}
+
+	fmt.Printf("\n")
+	return nil
+}
+
+func addOffsets(offsets []uint32, expr string) ([]bpf.Instruction, error) {
+	// LinkTypeRaw == Packet begins directly with an IPv4 or IPv6 header
+	// tcpdump defines:
+	//  LINKTYPE_RAW = 101 (https://www.tcpdump.org/linktypes.html)
+	//  DLT_RAW = 12 (https://github.com/the-tcpdump-group/libpcap/blob/master/pcap/dlt.h#L88)
+	// layers.LinkTypeRaw uses 101, but it seems 12 is expected here
+	filter, err := internal.TcpdumpExprToBPF(expr, layers.LinkType(12))
+	if err != nil {
+		return nil, err
+	}
+
+	return withOffsets(offsets, filter)
+}
+
+// withOffsets generates a new filter from filter, using a fixed set of offsets into the packet
+func withOffsets(offsets []uint32, filter []bpf.Instruction) ([]bpf.Instruction, error) {
+	// Final filter with all the offsets added
+	newFilter := []bpf.Instruction{}
+
+	// Sort the offsets so that the filter with the smallest offset is first
+	// Ensures that the smallest offset can match even if the packet is shorted than the biggest offset
+	sort.Slice(offsets, func(i, j int) bool {
+		return offsets[i] < offsets[j]
+	})
+
+	for _, offset := range offsets {
+		offsetFilter, err := withOffset(offset, filter)
+		if err != nil {
+			return nil, err
+		}
+
+		newFilter = append(newFilter, offsetFilter...)
+	}
+
+	// No filters matched
+	return append(newFilter, bpf.RetConstant{Val: 0}), nil
+}
+
+// withOffset rewrites filter to use a fixed offset into the packet
+// new filter will return on match, fall through on no match
+func withOffset(offset uint32, filter []bpf.Instruction) ([]bpf.Instruction, error) {
+	newFilter := []bpf.Instruction{}
+
+	// Appended to the end of newFilter to handle RetA
+	// By only adding instructions between filters, we don't need to rewrite jump offsets as they're relative
+	retATrailer := []bpf.Instruction{
+		// No match, fall through to the next filter
+		bpf.JumpIf{Cond: bpf.JumpEqual, Val: 0, SkipTrue: 1},
+		bpf.RetA{},
+	}
+
+	for pc, insn := range filter {
+		// skip to go to the end of the filter, start of retATrailer
+		skipEnd := uint32(len(filter) - pc - 1)
+
+		switch i := insn.(type) {
+		// All loads can just use a new offset into the packet
+		case bpf.LoadAbsolute:
+			newOff, err := addOffset(i.Off, uint32(offset))
+			if err != nil {
+				return nil, err
+			}
+			insn = bpf.LoadAbsolute{Off: newOff, Size: i.Size}
+		case bpf.LoadMemShift:
+			newOff, err := addOffset(i.Off, uint32(offset))
+			if err != nil {
+				return nil, err
+			}
+			insn = bpf.LoadMemShift{Off: newOff}
+		case bpf.LoadIndirect:
+			newOff, err := addOffset(i.Off, uint32(offset))
+			if err != nil {
+				return nil, err
+			}
+			insn = bpf.LoadIndirect{Off: newOff, Size: i.Size}
+
+		case bpf.RetA:
+			// Jump to retATrailer
+			insn = bpf.Jump{Skip: skipEnd}
+
+		case bpf.RetConstant:
+			// No match, jump to next filter (after retATrailer)
+			// We can keep matches, as we don't need to run any more filters
+			if i.Val == 0 {
+				insn = bpf.Jump{Skip: skipEnd + uint32(len(retATrailer))}
+			}
+
+		// Need magic to handle extensions such as length
+		case bpf.LoadExtension, bpf.RawInstruction:
+			return nil, errors.Errorf("BPF instruction %v unsupported", i)
+		}
+
+		newFilter = append(newFilter, insn)
+	}
+
+	return append(newFilter, retATrailer...), nil
+}
+
+// addOffset adds an offset, checking for overflow
+func addOffset(loadOffset, addedOffset uint32) (uint32, error) {
+	if math.MaxUint32-loadOffset < addedOffset {
+		return 0, errors.Errorf("offset %d too large", addedOffset)
+	}
+
+	return loadOffset + addedOffset, nil
+}

--- a/cmd/bpfoff/main_test.go
+++ b/cmd/bpfoff/main_test.go
@@ -1,0 +1,239 @@
+package main
+
+import (
+	"math"
+	"net"
+	"testing"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	"golang.org/x/net/bpf"
+)
+
+func TestOffsets(t *testing.T) {
+	offsets := []uint32{0, 2, 7, 24}
+
+	// UDP tests LoadIndirect handling as filter needs to load IP header length
+	filter, err := addOffsets(offsets, "ip and udp port 53")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	checkOffsets(t, filter, offsets, true,
+		&layers.IPv4{
+			Version:  4,
+			Protocol: layers.IPProtocolUDP,
+			SrcIP:    net.ParseIP("1.2.3.4"),
+			DstIP:    net.ParseIP("5.6.7.8"),
+		},
+		&layers.UDP{
+			SrcPort: 1234,
+			DstPort: 53,
+		},
+		gopacket.Payload([]byte{1, 2, 3, 4}),
+	)
+
+	checkOffsets(t, filter, offsets, false,
+		&layers.IPv4{
+			Version:  4,
+			Protocol: layers.IPProtocolUDP,
+			SrcIP:    net.ParseIP("1.2.3.4"),
+			DstIP:    net.ParseIP("5.6.7.8"),
+		},
+		&layers.UDP{
+			SrcPort: 1234,
+			DstPort: 54,
+		},
+		gopacket.Payload([]byte{1, 2, 3, 4}),
+	)
+}
+
+func TestOffsetOrder(t *testing.T) {
+	// Large offset first, bigger than length of packets
+	// If addOffsets(0 doesn't sort, a small input packet could never match:
+	// the large offset filter would run first, making an out of bounds read
+	offsets := []uint32{100, 2}
+
+	filter, err := addOffsets(offsets, "ip6 and host dead::beef")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	checkOffsets(t, filter, offsets, true,
+		&layers.IPv6{
+			Version: 6,
+			SrcIP:   net.ParseIP("dead::beef"),
+			DstIP:   net.ParseIP("beef::afaf"),
+		},
+	)
+
+	checkOffsets(t, filter, offsets, false,
+		&layers.IPv6{
+			Version: 6,
+			SrcIP:   net.ParseIP("defd::beef"),
+			DstIP:   net.ParseIP("beef::afaf"),
+		},
+	)
+}
+
+func TestOffsetOverflow(t *testing.T) {
+	offsets := []uint32{math.MaxUint32 - 1}
+
+	// Just big enough
+	_, err := addOffsets(offsets, "ip[1] == 4")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Just too small
+	_, err = addOffsets(offsets, "ip[2] == 4")
+	if err == nil {
+		t.Fatal("offset overflow accepted")
+	}
+}
+
+func TestUnsupportedInsn(t *testing.T) {
+	offsets := []uint32{4, 0}
+
+	_, err := withOffsets(offsets, []bpf.Instruction{
+		bpf.LoadExtension{},
+	})
+	if err == nil {
+		t.Fatal("extension accepted")
+	}
+
+	_, err = withOffsets(offsets, []bpf.Instruction{
+		// Load absolute size 3
+		bpf.RawInstruction{Op: 0x23},
+	})
+	if err == nil {
+		t.Fatal("bad instruction accepted")
+	}
+}
+
+func TestRetConstant(t *testing.T) {
+	offsets := []uint32{4, 0}
+
+	// match if pkt[0] == 2
+	filter, err := withOffsets(offsets, []bpf.Instruction{
+		bpf.LoadAbsolute{Off: 0, Size: 1},
+		bpf.JumpIf{Cond: bpf.JumpEqual, Val: 2, SkipTrue: 1},
+		bpf.RetConstant{Val: 0},
+		bpf.RetConstant{Val: 1},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	checkOffsets(t, filter, offsets, true, gopacket.Payload([]byte{2}))
+	checkOffsets(t, filter, offsets, false, gopacket.Payload([]byte{1}))
+}
+
+func TestRetA(t *testing.T) {
+	offsets := []uint32{4, 9, 0}
+
+	// match if pkt[0] != 0
+	filter, err := withOffsets(offsets, []bpf.Instruction{
+		bpf.LoadAbsolute{Off: 0, Size: 1},
+		bpf.RetA{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	checkOffsets(t, filter, offsets, true, gopacket.Payload([]byte{2}))
+	checkOffsets(t, filter, offsets, false, gopacket.Payload([]byte{0}))
+}
+
+func TestLoadAbsolute(t *testing.T) {
+	offsets := []uint32{7, 4, 0}
+
+	// match if pkt[6] == 6
+	filter, err := withOffsets(offsets, []bpf.Instruction{
+		bpf.LoadAbsolute{Off: 6, Size: 1},
+		bpf.JumpIf{Cond: bpf.JumpEqual, Val: 6, SkipTrue: 1},
+		bpf.RetConstant{Val: 0},
+		bpf.RetConstant{Val: 1},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	checkOffsets(t, filter, offsets, true, gopacket.Payload([]byte{0, 1, 2, 3, 4, 5, 6}))
+	checkOffsets(t, filter, offsets, false, gopacket.Payload([]byte{0, 1, 2, 3, 4, 5, 7}))
+	// Out of bounds
+	checkOffsets(t, filter, offsets, false, gopacket.Payload([]byte{1, 2, 3}))
+}
+
+func TestLoadIndirect(t *testing.T) {
+	offsets := []uint32{4, 0, 10}
+
+	// match if pkt[pkt[0] + 3] == 7
+	filter, err := withOffsets(offsets, []bpf.Instruction{
+		bpf.LoadAbsolute{Off: 0, Size: 1},
+		bpf.TAX{},
+		bpf.LoadIndirect{Off: 3, Size: 1},
+		bpf.JumpIf{Cond: bpf.JumpEqual, Val: 7, SkipTrue: 1},
+		bpf.RetConstant{Val: 0},
+		bpf.RetConstant{Val: 1},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	checkOffsets(t, filter, offsets, true, gopacket.Payload([]byte{2, 0, 0, 0, 0, 7, 0}))
+	checkOffsets(t, filter, offsets, true, gopacket.Payload([]byte{3, 0, 0, 0, 0, 6, 7}))
+	checkOffsets(t, filter, offsets, false, gopacket.Payload([]byte{2, 0, 0, 0, 7, 0, 7}))
+	// Out of bounds
+	checkOffsets(t, filter, offsets, false, gopacket.Payload([]byte{0}))
+}
+
+func TestLoadMemShift(t *testing.T) {
+	offsets := []uint32{4, 0, 10}
+
+	// match if pkt[4 * (pkt[2] & 0xf)] == 20
+	filter, err := withOffsets(offsets, []bpf.Instruction{
+		bpf.LoadMemShift{Off: 2},
+		bpf.TXA{},
+		bpf.JumpIf{Cond: bpf.JumpEqual, Val: 20, SkipTrue: 1},
+		bpf.RetConstant{Val: 0},
+		bpf.RetConstant{Val: 1},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	checkOffsets(t, filter, offsets, true, gopacket.Payload([]byte{1, 0, 5, 0}))
+	checkOffsets(t, filter, offsets, true, gopacket.Payload([]byte{1, 0, 21}))
+	checkOffsets(t, filter, offsets, false, gopacket.Payload([]byte{2, 0, 6, 0}))
+	// Out of bounds
+	checkOffsets(t, filter, offsets, false, gopacket.Payload([]byte{3, 0}))
+}
+
+func checkOffsets(tb testing.TB, filter []bpf.Instruction, offsets []uint32, expected bool, packet ...gopacket.SerializableLayer) {
+	tb.Helper()
+
+	vm, err := bpf.NewVM(filter)
+	if err != nil {
+		tb.Fatal(err)
+	}
+
+	buf := gopacket.NewSerializeBuffer()
+	err = gopacket.SerializeLayers(buf, gopacket.SerializeOptions{FixLengths: true}, packet...)
+	if err != nil {
+		tb.Fatal(err)
+	}
+
+	for _, offset := range offsets {
+		pkt := append(make([]byte, offset), buf.Bytes()...)
+
+		res, err := vm.Run(pkt)
+		if err != nil {
+			tb.Fatal(err)
+		}
+
+		if (res != 0) != expected {
+			tb.Fatalf("Offset %v\npacket %v\nfilter %v\n\n", offset, pkt, filter)
+		}
+	}
+}

--- a/cmd/xdpcap/flags.go
+++ b/cmd/xdpcap/flags.go
@@ -9,6 +9,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/cloudflare/xdpcap/internal"
+
 	"github.com/google/gopacket/layers"
 	"github.com/pkg/errors"
 	"golang.org/x/net/bpf"
@@ -92,7 +94,7 @@ func parseFilter(expr string, linkType layers.LinkType) ([]bpf.Instruction, erro
 		return parsecBPF(expr)
 	}
 
-	return tcpdumpExprToBPF(expr, linkType)
+	return internal.TcpdumpExprToBPF(expr, linkType)
 }
 
 // parsecBPF parses a string of cBPF 4 tuple instructions, formatted as:

--- a/cmd/xdpcap/flags_test.go
+++ b/cmd/xdpcap/flags_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cloudflare/xdpcap/internal"
+
 	"github.com/google/gopacket/layers"
 	"golang.org/x/net/bpf"
 )
@@ -280,7 +282,7 @@ func requireFlags(tb testing.TB, output string, expected, actual flags) {
 
 	// No expected filter, expected filter is filterExpr compiled with libpcap
 	if expected.filterOpts.filter == nil {
-		filter, err := tcpdumpExprToBPF(expected.filterExpr, expected.linkType)
+		filter, err := internal.TcpdumpExprToBPF(expected.filterExpr, expected.linkType)
 		if err != nil {
 			tb.Fatalf("Expected filterExpr %v can't be compiled: %v\n", expected.filterExpr, err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,6 @@ require (
 	github.com/mdlayher/raw v0.0.0-20190315120451-8be9e99c38b6 // indirect
 	github.com/newtools/ebpf v0.0.0-20190528141928-995442b23c95
 	github.com/pkg/errors v0.8.1
-	golang.org/x/net v0.0.0-20190603091049-60506f45cf65
-	golang.org/x/sys v0.0.0-20190602015325-4c4f7f33c9ed
+	golang.org/x/net v0.0.0-20190607181551-461777fb6f67
+	golang.org/x/sys v0.0.0-20190608050228-5b15430b70e3
 )

--- a/go.sum
+++ b/go.sum
@@ -15,11 +15,11 @@ github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190313220215-9f648a60d977/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190320064053-1272bf9dcd53/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/net v0.0.0-20190603091049-60506f45cf65 h1:+rhAzEzT3f4JtomfC371qB+0Ola2caSKcY69NUBZrRQ=
-golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
+golang.org/x/net v0.0.0-20190607181551-461777fb6f67 h1:rJJxsykSlULwd2P2+pg/rtnwN2FrWp4IuCxOSyS0V00=
+golang.org/x/net v0.0.0-20190607181551-461777fb6f67/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190502175342-a43fa875dd82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190602015325-4c4f7f33c9ed h1:uPxWBzB3+mlnjy9W58qY1j/cjyFjutgw/Vhan2zLy/A=
-golang.org/x/sys v0.0.0-20190602015325-4c4f7f33c9ed/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190608050228-5b15430b70e3 h1:xUZPeCzQtkdgRi9RjXIA+3w3RdyDLPqiaJlza5Fqpog=
+golang.org/x/sys v0.0.0-20190608050228-5b15430b70e3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/internal/tcpdump.go
+++ b/internal/tcpdump.go
@@ -1,4 +1,4 @@
-package main
+package internal
 
 import (
 	"github.com/google/gopacket/layers"
@@ -9,7 +9,7 @@ import (
 )
 
 // tcpdumpExprToBPF converts a tcpdump / libpcap filter expression to cBPF using libpcap
-func tcpdumpExprToBPF(filterExpr string, linkType layers.LinkType) ([]bpf.Instruction, error) {
+func TcpdumpExprToBPF(filterExpr string, linkType layers.LinkType) ([]bpf.Instruction, error) {
 	// We treat any != 0 filter return code as a match
 	insns, err := pcap.CompileBPFFilter(linkType, 1, filterExpr)
 	if err != nil {


### PR DESCRIPTION
Add a new tool, `bpfoff` that generates a cBPF filter matching encapsulated packets. This can be used with `xdpcap`'s raw BPF filter support.