### PR TITLE
Allow calling Patch on nil Hook

### DIFF
--- a/hook.go
+++ b/hook.go
@@ -60,8 +60,14 @@ func (h *Hook) Rm() error {
 	return errors.Wrapf(os.Remove(h.fileName), "file %s", h.fileName)
 }
 
-// Patch edits all programs in the spec that refer to hookMapSymbol to use this hook
+// Patch edits all programs in the spec that refer to hookMapSymbol to use this hook.
+//
+// This function is a no-op if called on a nil Hook.
 func (h *Hook) Patch(spec *ebpf.CollectionSpec, hookMapSymbol string) error {
+	if h == nil {
+		return nil
+	}
+
 	collectionAbi := ebpf.CollectionABI{
 		Maps: map[string]*ebpf.MapABI{
 			hookMapSymbol: &HookMapABI,


### PR DESCRIPTION
The common use of Hook looks like the following:

    func(h *Hook) {
      if h != nil {
        if err := h.Patch(...); err != nil {
          ...
        }
      }
      ...

Allow users to call Patch on a nil Hook, which simplifies the code to:

    func(h *Hook) {
      if err := h.Patch(...); err != nil {
        ...
      }
      ...