### PR TITLE
stop using deprecated ebpf.MapABI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 dist: xenial
 
 go:
-  - 1.12.x
+  - 1.15.x
 
 env:
   - GO111MODULE=on

--- a/cmd/xdpcap/filter.go
+++ b/cmd/xdpcap/filter.go
@@ -108,7 +108,7 @@ func newFilterWithMap(hookMap *ebpf.Map, opts filterOpts) (*filter, error) {
 func allActions(hookMap *ebpf.Map) []xdpAction {
 	actions := []xdpAction{}
 
-	for i := 0; i < int(hookMap.ABI().MaxEntries); i++ {
+	for i := 0; i < int(hookMap.MaxEntries()); i++ {
 		actions = append(actions, xdpAction(i))
 	}
 

--- a/cmd/xdpcap/program.go
+++ b/cmd/xdpcap/program.go
@@ -48,8 +48,8 @@ func newProgram(filter []bpf.Instruction, action xdpAction, perfMap *ebpf.Map) (
 		return nil, errors.Wrap(err, "creating metrics map")
 	}
 
-	if perfMap.ABI().Type != ebpf.PerfEventArray {
-		return nil, errors.Errorf("invalid perf map ABI, expected type %s, have %s", ebpf.PerfEventArray, perfMap.ABI().Type)
+	if perfMap.Type() != ebpf.PerfEventArray {
+		return nil, errors.Errorf("invalid perf map ABI, expected type %s, have %s", ebpf.PerfEventArray, perfMap.Type())
 	}
 
 	// Labels of blocks

--- a/go.mod
+++ b/go.mod
@@ -9,4 +9,4 @@ require (
 	golang.org/x/sys v0.0.0-20200430082407-1f5687305801
 )
 
-go 1.12
+go 1.14

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/cloudflare/xdpcap
 
 require (
-	github.com/cilium/ebpf v0.0.0-20200430085911-a0f791bb51cb
+	github.com/cilium/ebpf v0.1.0
 	github.com/cloudflare/cbpfc v0.0.0-20191024102745-5470c854fd38
 	github.com/google/gopacket v1.1.17
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,11 @@
 github.com/cilium/ebpf v0.0.0-20191024101557-7dc533ea7755 h1:rtv1yoAAvNBtuzv1K7imUJgB0RAF6LC61qUHQ2MZT20=
 github.com/cilium/ebpf v0.0.0-20191024101557-7dc533ea7755/go.mod h1:MA5e5Lr8slmEg9bt0VpxxWqJlO4iwu3FBdHUzV7wQVg=
-github.com/cilium/ebpf v0.0.0-20200430085911-a0f791bb51cb h1:drJ3dIxT8Nga1fJqPyMn+ZheZQeVscNw+4YKJkSLVSw=
-github.com/cilium/ebpf v0.0.0-20200430085911-a0f791bb51cb/go.mod h1:XT+cAw5wfvsodedcijoh1l9cf7v1x9FlFB/3VmF/O8s=
+github.com/cilium/ebpf v0.1.0 h1:x/yQklFd+2dSQXS077Yn5nHkQ1+xXPP21HpjXyPEKF0=
+github.com/cilium/ebpf v0.1.0/go.mod h1:To2CFviqOWL/M0gIMsvSMlqe7em/l1ALkX1PyjrX2Qs=
 github.com/cloudflare/cbpfc v0.0.0-20191024102745-5470c854fd38 h1:D5rGShqKLHli2Ix0SEzPw9BmYxlD6vHwrXcgBVan+jc=
 github.com/cloudflare/cbpfc v0.0.0-20191024102745-5470c854fd38/go.mod h1:wJRgDYys03AoU7bpcBinqBG3oWfBqWfwSTXr0tsU8Bw=
+github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gopacket v1.1.17 h1:rMrlX2ZY2UbvT+sdz3+6J+pp2z+msCq9MxTU6ymxbBY=
 github.com/google/gopacket v1.1.17/go.mod h1:UdDNZ1OO62aGYVnPhxT1U6aI7ukYtA/kB8vaU0diBUM=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=

--- a/internal/abi.go
+++ b/internal/abi.go
@@ -2,24 +2,30 @@ package internal
 
 import (
 	"github.com/cilium/ebpf"
-	"github.com/cloudflare/xdpcap"
 	"github.com/pkg/errors"
 )
+
+// HookMapSpec is the ABI of the underlying prog map created
+var HookMapSpec = &ebpf.MapSpec{
+	Type:       ebpf.ProgramArray,
+	KeySize:    4, // sizeof(int)
+	ValueSize:  4, // sizeof(int)
+	MaxEntries: 4, // current number of XDP actions
+}
 
 // CheckHookMap checks the given map against HookMapABI to have appropriate values
 // Only checks Type, KeySize, ValueSize
 func CheckHookMap(m *ebpf.Map) error {
-	abi := m.ABI()
-	if abi.Type != xdpcap.HookMapABI.Type {
-		return errors.Errorf("expected map type %s, have %s", xdpcap.HookMapABI.Type, abi.Type)
+	if m.Type() != HookMapSpec.Type {
+		return errors.Errorf("expected map type %s, have %s", HookMapSpec.Type, m.Type())
 	}
 
-	if abi.KeySize != xdpcap.HookMapABI.KeySize {
-		return errors.Errorf("expected key size to be %d, have %d", xdpcap.HookMapABI.KeySize, abi.KeySize)
+	if m.KeySize() != HookMapSpec.KeySize {
+		return errors.Errorf("expected key size to be %d, have %d", HookMapSpec.KeySize, m.KeySize())
 	}
 
-	if abi.ValueSize != xdpcap.HookMapABI.ValueSize {
-		return errors.Errorf("expected value size to be %d, have %d", xdpcap.HookMapABI.ValueSize, abi.ValueSize)
+	if m.ValueSize() != HookMapSpec.ValueSize {
+		return errors.Errorf("expected value size to be %d, have %d", HookMapSpec.ValueSize, m.ValueSize())
 	}
 
 	return nil

--- a/internal/abi_test.go
+++ b/internal/abi_test.go
@@ -1,23 +1,14 @@
 package internal
 
 import (
-	"github.com/cilium/ebpf"
-	"github.com/cloudflare/xdpcap"
 	"testing"
-)
 
-const hookSymbol = "foo"
+	"github.com/cilium/ebpf"
+)
 
 // Test CheckHookMap with valid and invalid HookMap ABI
 func TestCheckHookMap(t *testing.T) {
-	scpec := &ebpf.MapSpec{
-		Name:       ebpf.SanitizeName(hookSymbol, '_'),
-		Type:       xdpcap.HookMapABI.Type,
-		KeySize:    xdpcap.HookMapABI.KeySize,
-		ValueSize:  xdpcap.HookMapABI.ValueSize,
-		MaxEntries: 4,
-	}
-	valid, err := ebpf.NewMap(scpec)
+	valid, err := ebpf.NewMap(HookMapSpec)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -27,8 +18,9 @@ func TestCheckHookMap(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	scpec.Type = ebpf.Array
-	inValid, err := ebpf.NewMap(scpec)
+	spec := HookMapSpec.Copy()
+	spec.Type = ebpf.Array
+	inValid, err := ebpf.NewMap(spec)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Replace usage of MapABI with a MapSpec. This works out to remove some duplication as well.

