### PR TITLE
Optionally limit packet count

### DIFF
--- a/cmd/xdpcap/flags.go
+++ b/cmd/xdpcap/flags.go
@@ -181,6 +181,8 @@ type flags struct {
 	// Filter provided as input. Not in any particular format, for metadata / debugging only.
 	filterExpr string
 	filterOpts filterOpts
+
+	maxPackets uint64
 }
 
 // parseFlags creates the flags, and attempts to parse args.
@@ -196,6 +198,7 @@ func parseFlags(name string, args []string) (flags, error) {
 
 	flags.IntVar(&flags.filterOpts.perfPerCPUBuffer, "buffer", 8192, "Per CPU perf buffer size to create (`bytes`)")
 	flags.IntVar(&flags.filterOpts.perfWatermark, "watermark", 1, "Perf watermark (`bytes`). Must be < buffer.")
+	flags.Uint64Var(&flags.maxPackets, "c", 0, "Maximum number of packets to capture across all `actions`. 0 indicates unlimited")
 	flags.BoolVar(&flags.quiet, "q", false, "Don't print statistics")
 	flags.BoolVar(&flags.flush, "flush", false, "Flush pcap data written to <output> for every packet received")
 

--- a/cmd/xdpcap/flags_test.go
+++ b/cmd/xdpcap/flags_test.go
@@ -136,7 +136,7 @@ func TestFilterRawInvalid(t *testing.T) {
 func TestOptions(t *testing.T) {
 	output := tempOutput(t)
 
-	flags, err := parseFlags("", []string{"-buffer", "1234", "-watermark", "5678", "-q", "-flush", "-actions", "pass,drop", "-linktype", "802.11", "foo", output})
+	flags, err := parseFlags("", []string{"-buffer", "1234", "-watermark", "5678", "-q", "-flush", "-actions", "pass,drop", "-linktype", "802.11", "-c", "1000", "foo", output})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -148,6 +148,7 @@ func TestOptions(t *testing.T) {
 	expected.flush = true
 	expected.filterOpts.actions = []xdpAction{xdpPass, xdpDrop}
 	expected.linkType = layers.LinkTypeIEEE802_11
+	expected.maxPackets = 1000
 
 	requireFlags(t, output, expected, flags)
 }

--- a/cmd/xdpcap/main.go
+++ b/cmd/xdpcap/main.go
@@ -106,6 +106,8 @@ func capture(flags flags) error {
 
 	// Write out a pcap file from aggregated packets
 	go func() {
+		totalPackets := uint64(0)
+
 		for {
 			pkt, err := filter.read()
 			switch {
@@ -132,6 +134,13 @@ func capture(flags flags) error {
 				err = pcapWriter.Flush()
 				if err != nil {
 					fmt.Fprintln(os.Stderr, "Error flushing data:", err)
+				}
+			}
+
+			if flags.maxPackets != 0 {
+				totalPackets++
+				if totalPackets >= flags.maxPackets {
+					sigs <- syscall.SIGTERM
 				}
 			}
 		}


### PR DESCRIPTION
Adds a new flag, `-c`, which allows for the capture to stop when a certain number of matched packets have been hit similar to what tcpdump offers. Having the capture utility be capable of exiting on this condition is helpful in the following cases:
- The application is ran with a filter that may match a significant number of traffic, but the user only wants a fixed size sample
- One wants to run the program unattended until a certain amount of packets have been captured, but without the burden of having to kill it after a certain amount of time using `timeout` and risking either ending up with too few or too many packets

These changes can be tested by running xdpcap with the `-c` flag set to a non-zero value, observing it exiting, and then verifying that the resulting packet capture only has the requested amount.